### PR TITLE
Speed up Decision Transformer workflow

### DIFF
--- a/DT_run.py
+++ b/DT_run.py
@@ -42,7 +42,9 @@ if __name__ == "__main__":
     compute = False
 
     device = torch.device(hyper_params["device"])
-    torch.autograd.set_detect_anomaly(True)
+    # Enable cuDNN autotuner for faster convolutions on GPU
+    if device.type == "cuda":
+        torch.backends.cudnn.benchmark = True
 
     if args.agent_model == "dt":
         agent = DT_Agent(**hyper_params)


### PR DESCRIPTION
## Summary
- Enable cuDNN autotuner and remove anomaly detection overhead
- Compile Decision Transformer network and streamline action selection
- Simplify training loop by using pre-padded batches directly

## Testing
- `python -m py_compile DT_run.py agent.py`
- `python - <<'PY'
from agent import DT_Agent
agent = DT_Agent(state_size=1, action_size=2, feature_size=3, buffer_size=10, batch_size=2,
                 update_every=1, num_layers=1, lr=1e-3, layer_size=64, device='cpu', max_len=5, seed=0)
print('agent created')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68975910d4ac832fa0724a1ee45acd7a