### PR TITLE
Add CQL agent implementation

### DIFF
--- a/agent_run.py
+++ b/agent_run.py
@@ -49,6 +49,8 @@ if __name__ == "__main__":
         agent = DQN_Agent(**hyper_params)
     elif args.agent_model == "fqf":
         agent = FQF_Agent(**hyper_params)
+    elif args.agent_model == "cql":
+        agent = CQL_Agent(**hyper_params)
     elif args.agent_model == "pomo":
         agent = POMO_Agent(**hyper_params)
     print("Agent", args.agent_model, "initialized", flush=True)


### PR DESCRIPTION
## Summary
- introduce `CQL_Agent` implementing Conservative Q-Learning atop DQN
- allow selecting the CQL agent via `agent_model=cql` in `agent_run`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689764bcbcf4832fb2ccd8deca9b8cba