### PR TITLE
Use itertuples for DataFrame iteration

### DIFF
--- a/DT_run.py
+++ b/DT_run.py
@@ -113,10 +113,10 @@ if __name__ == "__main__":
 
     wandb.init(project="simu_ff", name=args.model_name, config=hyper_params)
 
-    for idx, inter in df_pc.iterrows():
-    
-        num_inter, date, pdd, required_departure, zone, duration, month, day, hour, minute, \
-        coord_x, coord_y, month_sin, month_cos, day_sin, day_cos, hour_sin, hour_cos = inter
+    for row in df_pc.itertuples(index=True, name=None):
+
+        idx, num_inter, date, pdd, required_departure, zone, duration, month, day, hour, minute, \
+        coord_x, coord_y, month_sin, month_cos, day_sin, day_cos, hour_sin, hour_cos = row
         
         dic_ff = update_duration(date, old_date, current_ff_inter, dic_ff)
     

--- a/agent_run.py
+++ b/agent_run.py
@@ -111,11 +111,11 @@ if __name__ == "__main__":
 
     wandb.init(project="simu_ff", name=args.model_name, config=hyper_params)
 
-    # for idx, inter in tqdm(df_pc.iloc[:-20].iterrows(), total=len(df_pc.iloc[:-20])):
-    for idx, inter in df_pc.iterrows():
-    
-        num_inter, date, pdd, required_departure, zone, duration, month, day, hour, minute, \
-        coord_x, coord_y, month_sin, month_cos, day_sin, day_cos, hour_sin, hour_cos = inter
+    # for idx, inter in tqdm(df_pc.iloc[:-20].itertuples(index=True, name=None), total=len(df_pc.iloc[:-20])):
+    for row in df_pc.itertuples(index=True, name=None):
+
+        idx, num_inter, date, pdd, required_departure, zone, duration, month, day, hour, minute, \
+        coord_x, coord_y, month_sin, month_cos, day_sin, day_cos, hour_sin, hour_cos = row
         
         dic_ff = update_duration(date, old_date, current_ff_inter, dic_ff)
     

--- a/collective_functions.py
+++ b/collective_functions.py
@@ -383,14 +383,15 @@ def create_dic_roles(df_vehicles_history):
     df_vehicles_history["Fonction"] = df_vehicles_history["Fonction"].replace(dic_replace)
     
     dic_roles = {}
-    
-    for idx, row in df_vehicles_history.iterrows():
-    
-        tm = row["Type Matériel"]
-        t = row["Type"]
-        f = row["Fonction"]
-        ofo = row["Ordre Fonction Occupee"]
-        fo = row["Fonction Occupee"]
+
+    for row in df_vehicles_history.itertuples(index=False):
+
+        row_dict = row._asdict()
+        tm = row_dict["Type Matériel"]
+        t = row_dict["Type"]
+        f = row_dict["Fonction"]
+        ofo = row_dict["Ordre Fonction Occupee"]
+        fo = row_dict["Fonction Occupee"]
         
         if (tm != ""):
             if tm not in dic_roles:

--- a/generate_environment.py
+++ b/generate_environment.py
@@ -149,8 +149,8 @@ def precompute_prob_dict(df_inter_clean):
 
     nested_dict = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
 
-    for _, row in df_inter_clean.iterrows():
-        incident, area, list_of_strings = row["incident_name"], row["area_type"], tuple(row["real_func"])
+    for row in df_inter_clean.itertuples(index=False):
+        incident, area, list_of_strings = row.incident_name, row.area_type, tuple(row.real_func)
         nested_dict[incident][area][list_of_strings] += 1
     
     nested_dict = {k: {kk: dict(vv) for kk, vv in v.items()} for k, v in nested_dict.items()}
@@ -312,10 +312,10 @@ def create_responses(df_responses, df_rank_incident):
     df_responses_short =  df_responses[df_responses['Nom'].isin(valeurs_a_chercher)].reset_index(drop = True)
     dic_inc_ar_mat = {}
 
-    for index, row in df_responses_short.iterrows():
-        nom = row['Nom']
-        secteur = row['Secteur']
-        materiel = row['Materiel']
+    for row in df_responses_short.itertuples(index=False):
+        nom = row.Nom
+        secteur = row.Secteur
+        materiel = row.Materiel
         
         materiel_dict = extract_bracket_number_and_clean(materiel)
         

--- a/sample.py
+++ b/sample.py
@@ -94,13 +94,13 @@ def gen_num_samples(num_samples, var):
 def new_df_sample(df_test, col, df_oversampled):
 
     list_of_df = []
-    for idx, row in df_test.iterrows():
-                
-        if len(df_oversampled[df_oversampled[col] == row[col]]) >= row["new_samples"]:
-            list_of_df.append(df_oversampled[df_oversampled[col] == row[col]].sample(int(row["new_samples"])))
-            
-        else:            
-            list_of_df.append(df_oversampled[df_oversampled[col] == row[col]])
+    for row in df_test.itertuples(index=False):
+
+        if len(df_oversampled[df_oversampled[col] == getattr(row, col)]) >= row.new_samples:
+            list_of_df.append(df_oversampled[df_oversampled[col] == getattr(row, col)].sample(int(row.new_samples)))
+
+        else:
+            list_of_df.append(df_oversampled[df_oversampled[col] == getattr(row, col)])
 
     return pd.concat(list_of_df, ignore_index=True)
 

--- a/simulation_start.py
+++ b/simulation_start.py
@@ -58,11 +58,11 @@ if __name__ == "__main__":
     action_size = 80
     
     
-    # for idx, inter in tqdm(df_pc.iloc[:-20].iterrows(), total=len(df_pc.iloc[:-20])): # offset to deal with reinfo
-    for idx, inter in df_pc.iterrows():
-    
-        num_inter, date, pdd, required_departure, zone, duration, month, day, hour, minute, \
-        coord_x, coord_y, month_sin, month_cos, day_sin, day_cos, hour_sin, hour_cos = inter
+    # for idx, inter in tqdm(df_pc.iloc[:-20].itertuples(index=True, name=None), total=len(df_pc.iloc[:-20])): # offset to deal with reinfo
+    for row in df_pc.itertuples(index=True, name=None):
+
+        idx, num_inter, date, pdd, required_departure, zone, duration, month, day, hour, minute, \
+        coord_x, coord_y, month_sin, month_cos, day_sin, day_cos, hour_sin, hour_cos = row
         
         dic_ff = update_duration(date, old_date, current_ff_inter, dic_ff)
     


### PR DESCRIPTION
## Summary
- replace pandas `iterrows` loops with `itertuples` for faster iteration across dataframes
- adjust associated row handling in data processing utilities and simulation scripts

## Testing
- `python -m py_compile agent_run.py simulation_start.py DT_run.py generate_environment.py sample.py collective_functions.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898c01b0ec4832fa49d04a72e353200