### PR TITLE
Restore iterrows usage outside runtime modules

### DIFF
--- a/collective_functions.py
+++ b/collective_functions.py
@@ -384,14 +384,13 @@ def create_dic_roles(df_vehicles_history):
     
     dic_roles = {}
 
-    for row in df_vehicles_history.itertuples(index=False):
+    for _, row in df_vehicles_history.iterrows():
 
-        row_dict = row._asdict()
-        tm = row_dict["Type Matériel"]
-        t = row_dict["Type"]
-        f = row_dict["Fonction"]
-        ofo = row_dict["Ordre Fonction Occupee"]
-        fo = row_dict["Fonction Occupee"]
+        tm = row["Type Matériel"]
+        t = row["Type"]
+        f = row["Fonction"]
+        ofo = row["Ordre Fonction Occupee"]
+        fo = row["Fonction Occupee"]
         
         if (tm != ""):
             if tm not in dic_roles:

--- a/generate_environment.py
+++ b/generate_environment.py
@@ -149,8 +149,10 @@ def precompute_prob_dict(df_inter_clean):
 
     nested_dict = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
 
-    for row in df_inter_clean.itertuples(index=False):
-        incident, area, list_of_strings = row.incident_name, row.area_type, tuple(row.real_func)
+    for _, row in df_inter_clean.iterrows():
+        incident = row["incident_name"]
+        area = row["area_type"]
+        list_of_strings = tuple(row["real_func"])
         nested_dict[incident][area][list_of_strings] += 1
     
     nested_dict = {k: {kk: dict(vv) for kk, vv in v.items()} for k, v in nested_dict.items()}
@@ -312,10 +314,10 @@ def create_responses(df_responses, df_rank_incident):
     df_responses_short =  df_responses[df_responses['Nom'].isin(valeurs_a_chercher)].reset_index(drop = True)
     dic_inc_ar_mat = {}
 
-    for row in df_responses_short.itertuples(index=False):
-        nom = row.Nom
-        secteur = row.Secteur
-        materiel = row.Materiel
+    for _, row in df_responses_short.iterrows():
+        nom = row["Nom"]
+        secteur = row["Secteur"]
+        materiel = row["Materiel"]
         
         materiel_dict = extract_bracket_number_and_clean(materiel)
         

--- a/sample.py
+++ b/sample.py
@@ -94,13 +94,15 @@ def gen_num_samples(num_samples, var):
 def new_df_sample(df_test, col, df_oversampled):
 
     list_of_df = []
-    for row in df_test.itertuples(index=False):
+    for _, row in df_test.iterrows():
 
-        if len(df_oversampled[df_oversampled[col] == getattr(row, col)]) >= row.new_samples:
-            list_of_df.append(df_oversampled[df_oversampled[col] == getattr(row, col)].sample(int(row.new_samples)))
+        if len(df_oversampled[df_oversampled[col] == row[col]]) >= row["new_samples"]:
+            list_of_df.append(
+                df_oversampled[df_oversampled[col] == row[col]].sample(int(row["new_samples"]))
+            )
 
         else:
-            list_of_df.append(df_oversampled[df_oversampled[col] == getattr(row, col)])
+            list_of_df.append(df_oversampled[df_oversampled[col] == row[col]])
 
     return pd.concat(list_of_df, ignore_index=True)
 


### PR DESCRIPTION
## Summary
- Replace itertuples loops with iterrows in collective utility functions
- Iterate with iterrows when computing environment probabilities and responses
- Switch sample generator to iterrows-based iteration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898c812dd7c832fb5c3ea9e7a973690