### PR TITLE
Clear PPO rollout storage after learning

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -229,6 +229,9 @@ class ActorCritic:
         )
         self.critic_optimizer.step()
 
+        # Clear rollout storage after learning to avoid reusing old trajectories
+        self.rollout_storage.clear()
+
         return {
             "actor_loss": actor_loss.detach().cpu().item(),
             "critic_loss": critic_loss.detach().cpu().item(),


### PR DESCRIPTION
## Summary
- clear the PPO rollout buffer after each learning update to avoid reusing stale trajectories

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f157be9a2c832f877b4abce022a40b